### PR TITLE
Ignore case for query language parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.dievision.sinicum</groupId>
   <artifactId>sinicum-server-parent</artifactId>
-  <version>0.9.4</version>
+  <version>0.9.5</version>
   <packaging>pom</packaging>
 
   <name>sinicum-server-parent</name>

--- a/sinicum-server-magnolia-5/pom.xml
+++ b/sinicum-server-magnolia-5/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.dievision.sinicum</groupId>
     <artifactId>sinicum-server-parent</artifactId>
-    <version>0.9.4</version>
+    <version>0.9.5</version>
   </parent>
 
   <artifactId>sinicum-server-magnolia-5</artifactId>

--- a/sinicum-server/pom.xml
+++ b/sinicum-server/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.dievision.sinicum</groupId>
     <artifactId>sinicum-server-parent</artifactId>
-    <version>0.9.4</version>
+    <version>0.9.5</version>
   </parent>
 
   <artifactId>sinicum-server</artifactId>

--- a/sinicum-server/src/main/java/com/dievision/sinicum/server/jcr/NodeQueryManager.java
+++ b/sinicum-server/src/main/java/com/dievision/sinicum/server/jcr/NodeQueryManager.java
@@ -40,7 +40,7 @@ public class NodeQueryManager {
                             long limit, long offset) {
         this.workspace = workspace;
         this.query = query;
-        this.language = language;
+        this.language = convertQueryLanguage(language);
         this.limit = limit;
         this.offset = offset;
     }
@@ -87,6 +87,24 @@ public class NodeQueryManager {
             return checkMethod;
         } catch (IntrospectionException e) {
             return false;
+        }
+    }
+
+    protected String getLanguage() {
+        return language;
+    }
+
+    private String convertQueryLanguage(String queryLanguage) {
+        if (Query.XPATH.equalsIgnoreCase(queryLanguage)) {
+            return Query.XPATH;
+        } else if (Query.SQL.equalsIgnoreCase(queryLanguage)) {
+            return Query.SQL;
+        } else if (Query.JCR_SQL2.equalsIgnoreCase(queryLanguage)) {
+            return Query.JCR_SQL2;
+        } else if (Query.JCR_JQOM.equalsIgnoreCase(queryLanguage)) {
+            return Query.JCR_JQOM;
+        } else {
+            return queryLanguage;
         }
     }
 }

--- a/sinicum-server/src/test/java/com/dievision/sinicum/server/jcr/NodeQueryManagerTest.java
+++ b/sinicum-server/src/test/java/com/dievision/sinicum/server/jcr/NodeQueryManagerTest.java
@@ -68,6 +68,54 @@ public class NodeQueryManagerTest extends JackrabbitTest45 {
         }
     }
 
+    @Test
+    public void testCaseInsensivityXPath() {
+        NodeQueryManager nodeQueryManager = new NodeQueryManager("config", QUERY, "xPath",
+                2, 2);
+        assertEquals(Query.XPATH, nodeQueryManager.getLanguage());
+
+    }
+
+    @Test
+    public void testCaseInsensivitySql() {
+        NodeQueryManager nodeQueryManager = new NodeQueryManager("config", QUERY, "sQl",
+                2, 2);
+        assertEquals(Query.SQL, nodeQueryManager.getLanguage());
+
+    }
+
+    @Test
+    public void testCaseInsensivityJcrSql2() {
+        NodeQueryManager nodeQueryManager = new NodeQueryManager("config", QUERY, "jcR-Sql2",
+                2, 2);
+        assertEquals(Query.JCR_SQL2, nodeQueryManager.getLanguage());
+
+    }
+
+    @Test
+    public void testCaseInsensivityJqm() {
+        NodeQueryManager nodeQueryManager = new NodeQueryManager("config", QUERY, "jcR-JqOm",
+                2, 2);
+        assertEquals(Query.JCR_JQOM, nodeQueryManager.getLanguage());
+
+    }
+
+    @Test
+    public void testCaseInsensivityNull() {
+        NodeQueryManager nodeQueryManager = new NodeQueryManager("config", QUERY, null,
+                2, 2);
+        assertEquals(null, nodeQueryManager.getLanguage());
+
+    }
+
+    @Test
+    public void testCaseInsensivitySomethingElse() {
+        NodeQueryManager nodeQueryManager = new NodeQueryManager("config", QUERY, "someThing",
+                2, 2);
+        assertEquals("someThing", nodeQueryManager.getLanguage());
+
+    }
+
     private List<NodeApiWrapper> getAllNodes() throws RepositoryException {
         NodeQueryManager nodeQueryManager = new NodeQueryManager("config", QUERY, Query.XPATH);
         return nodeQueryManager.executeQuery();


### PR DESCRIPTION
* to make the `xpath` `JCR-SQL2`-situation a bit easier to handle
* other paramers are lowercase as well, it would not be nice to have an exception for `JCR-SQL2`