### PR TITLE
Limit and offset are working again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.dievision.sinicum</groupId>
   <artifactId>sinicum-server-parent</artifactId>
-  <version>0.10.1</version>
+  <version>0.10.2</version>
   <packaging>pom</packaging>
 
   <name>sinicum-server-parent</name>

--- a/sinicum-server-magnolia-5/pom.xml
+++ b/sinicum-server-magnolia-5/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.dievision.sinicum</groupId>
     <artifactId>sinicum-server-parent</artifactId>
-    <version>0.10.1</version>
+    <version>0.10.2</version>
   </parent>
 
   <artifactId>sinicum-server-magnolia-5</artifactId>

--- a/sinicum-server/pom.xml
+++ b/sinicum-server/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.dievision.sinicum</groupId>
     <artifactId>sinicum-server-parent</artifactId>
-    <version>0.10.1</version>
+    <version>0.10.2</version>
   </parent>
 
   <artifactId>sinicum-server</artifactId>

--- a/sinicum-server/src/main/java/com/dievision/sinicum/server/jcr/NodeQueryManager.java
+++ b/sinicum-server/src/main/java/com/dievision/sinicum/server/jcr/NodeQueryManager.java
@@ -4,7 +4,6 @@ import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.MethodDescriptor;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -53,12 +52,10 @@ public class NodeQueryManager {
         if (limitAndOffsetSupported()) {
             try {
                 if (limit > 0) {
-                    Method m = qry.getClass().getDeclaredMethod("setLimit", Long.TYPE);
-                    m.invoke(qry, limit);
+                    qry.setLimit(limit);
                 }
                 if (offset > 0) {
-                    Method m = qry.getClass().getDeclaredMethod("setOffset", Long.TYPE);
-                    m.invoke(qry, offset);
+                    qry.setOffset(offset);
                 }
             } catch (Exception e) {
                 logger.error("Could not set limit or offset for query: " + e.toString());


### PR DESCRIPTION
During some update to some classes in the past, the limit and offset feature didn't work anymore.

I fixed this by calling the methods directly. Reflections are not needed, since we don't support jcr1 anymore.