### PR TITLE
The ProxyServlet can now use different targets

### DIFF
--- a/sinicum-server/pom.xml
+++ b/sinicum-server/pom.xml
@@ -29,11 +29,6 @@
         <version>${jerseyVersion}</version>
     </dependency>
     <dependency>
-        <groupId>org.glassfish.jersey.containers</groupId>
-        <artifactId>jersey-container-servlet</artifactId>
-        <version>${jerseyVersion}</version>
-    </dependency>
-    <dependency>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>jersey-media-json-jackson</artifactId>
         <version>${jerseyVersion}</version>

--- a/sinicum-server/src/main/java/com/dievision/sinicum/server/filters/ProxyEntry.java
+++ b/sinicum-server/src/main/java/com/dievision/sinicum/server/filters/ProxyEntry.java
@@ -1,0 +1,54 @@
+package com.dievision.sinicum.server.filters;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.regex.Pattern;
+
+public class ProxyEntry {
+    private Pattern proxyPattern;
+    private URI proxyTargetUri;
+    private static final String DEFAULT_PATH_PATTERN = "/.*";
+    private static final String DEFAULT_PROXY_TARGET_URI = "http://localhost:3000";
+    private static final Logger logger = LoggerFactory.getLogger(ProxyEntry.class);
+
+    public ProxyEntry() {
+        this(DEFAULT_PATH_PATTERN, DEFAULT_PROXY_TARGET_URI);
+    }
+
+    public ProxyEntry(String proxyPattern, String proxyTargetUri) {
+        this.proxyPattern = Pattern.compile(proxyPattern);
+        try {
+            this.proxyTargetUri = new URI(proxyTargetUri);
+        } catch (URISyntaxException e) {
+            logger.error("Error setting sinicum-server default proxy target: "
+                    + e.toString());
+        }
+    }
+
+    public boolean matchesPath(String path) {
+        if (path == null) {
+            return false;
+        } else {
+            return proxyPattern.matcher(path).matches();
+        }
+    }
+
+    public Pattern getProxyPattern() {
+        return proxyPattern;
+    }
+
+    public void setProxyPattern(String proxyPattern) {
+        this.proxyPattern = Pattern.compile(proxyPattern);
+    }
+
+    public URI getProxyTargetUri() {
+        return proxyTargetUri;
+    }
+
+    public void setProxyTargetUri(URI proxyTargetUri) {
+        this.proxyTargetUri = proxyTargetUri;
+    }
+}

--- a/sinicum-server/src/main/java/com/dievision/sinicum/server/filters/ProxyFilter.java
+++ b/sinicum-server/src/main/java/com/dievision/sinicum/server/filters/ProxyFilter.java
@@ -138,9 +138,9 @@ public class ProxyFilter {
         HttpClient proxyClient = createNewClient();
         try {
             // Execute the request
-            HttpResponse proxyResponse =
-                    proxyClient.execute(URIUtils.extractHost(
-                            ProxyFilterConfig.getInstance().getProxyTargetUri()), proxyRequest);
+            HttpResponse proxyResponse = proxyClient.execute(URIUtils.extractHost(
+                    ProxyFilterConfig.getInstance().getProxyTargetUri(
+                            proxyRequestUri)), proxyRequest);
 
             // Process the response
             int statusCode = proxyResponse.getStatusLine().getStatusCode();
@@ -297,7 +297,8 @@ public class ProxyFilter {
                 // the correct virtual server
                 if (headerName.equalsIgnoreCase(HttpHeaders.HOST)) {
                     HttpHost host = URIUtils.extractHost(
-                            ProxyFilterConfig.getInstance().getProxyTargetUri());
+                            ProxyFilterConfig.getInstance().getProxyTargetUri(
+                                    servletRequest.getRequestURI()));
                     headerValue = host.getHostName();
                     if (host.getPort() != -1) {
                         headerValue += ":" + host.getPort();
@@ -339,7 +340,8 @@ public class ProxyFilter {
 
     private String rewriteUrlFromRequest(HttpServletRequest request) {
         StringBuilder uri = new StringBuilder(500);
-        uri.append(ProxyFilterConfig.getInstance().getProxyTargetUri().toString());
+        uri.append(ProxyFilterConfig.getInstance().getProxyTargetUri(
+                request.getRequestURI()).toString());
         // Handle the path given to the servlet
         if (request.getRequestURI() != null) { //ex: /my/path.html
             uri.append(request.getRequestURI());
@@ -362,7 +364,8 @@ public class ProxyFilter {
 
     private String rewriteUrlFromResponse(HttpServletRequest request, String theUrl) {
         //TODO document example paths
-        if (theUrl.startsWith(ProxyFilterConfig.getInstance().getProxyTargetUri().toString())) {
+        if (theUrl.startsWith(ProxyFilterConfig.getInstance().getProxyTargetUri(
+                request.getRequestURI()).toString())) {
             String curUrl = request.getRequestURL().toString(); //no query
             String pathInfo = request.getRequestURI();
             if (pathInfo != null) {
@@ -371,7 +374,7 @@ public class ProxyFilter {
                 curUrl = curUrl.substring(0, curUrl.length() - pathInfo.length());
             }
             theUrl = curUrl + theUrl.substring(ProxyFilterConfig.getInstance()
-                    .getProxyTargetUri().toString().length());
+                    .getProxyTargetUri(request.getRequestURI()).toString().length());
         }
         return theUrl;
     }

--- a/sinicum-server/src/test/java/com/dievision/sinicum/server/filters/ProxyFilterConfigTest.java
+++ b/sinicum-server/src/test/java/com/dievision/sinicum/server/filters/ProxyFilterConfigTest.java
@@ -4,21 +4,21 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 
 public class ProxyFilterConfigTest {
     private static final Logger logger = LoggerFactory.getLogger(ProxyFilterConfigTest.class);
 
     @Test
-    public void testDefaultPattern() {
-        assertTrue(ProxyFilterConfig.getInstance().matchesPath("/.*"));
-        assertTrue(ProxyFilterConfig.getInstance().matchesPath("/something"));
-    }
+    public void testSetNewPattern() throws URISyntaxException {
+        ProxyEntry entry = new ProxyEntry("/something.*", "http://www.example.com");
 
-    @Test
-    public void testSetNewPattern() {
-        ProxyFilterConfig.getInstance().setProxyPattern("/something.*");
+        ProxyFilterConfig.getInstance().addProxyEntry(entry);
         ProxyFilterConfig config = ProxyFilterConfig.getInstance();
         assertTrue(config.matchesPath("/something"));
         assertTrue(config.matchesPath("/somethingnew"));
@@ -27,6 +27,25 @@ public class ProxyFilterConfigTest {
         assertFalse(config.matchesPath("/some"));
         assertFalse(config.matchesPath("/other"));
         assertFalse(config.matchesPath("/"));
+    }
+
+    @Test
+    public void testMultipleEntries() throws URISyntaxException {
+        ProxyEntry entry = new ProxyEntry("/something.*", "http://www.example.com");
+        ProxyFilterConfig.getInstance().addProxyEntry(entry);
+        ProxyEntry entry2 = new ProxyEntry("/otherpath.*", "http://www.dievision.de");
+        ProxyFilterConfig.getInstance().addProxyEntry(entry2);
+        ProxyEntry entry3 = new ProxyEntry("/.*", "http://www.the-rest.de");
+        ProxyFilterConfig.getInstance().addProxyEntry(entry3);
+
+        ProxyFilterConfig config = ProxyFilterConfig.getInstance();
+        assertTrue(config.matchesPath("/something"));
+        assertTrue(config.matchesPath("/otherpath"));
+
+        assertEquals(config.getProxyTargetUri("/something/more"),
+                new URI("http://www.example.com"));
+        assertEquals(config.getProxyTargetUri("/otherpath"), new URI("http://www.dievision.de"));
+        assertEquals(config.getProxyTargetUri("/123123123"), new URI("http://www.the-rest.de"));
     }
 
 }


### PR DESCRIPTION
In order to use one Magnolia CMS for multiple Rails Projects, I enhanced the ProxyServlet.

It can now be configured with multiple entries, so that the Servlet will decide where to send the request based on the path.

See the test to get a better idea, how it works.