### PR TITLE
Introducing a new cache key, that is scoped for site prefixes. Needed in a multisite environment.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.dievision.sinicum</groupId>
   <artifactId>sinicum-server-parent</artifactId>
-  <version>0.10.6</version>
+  <version>0.10.7</version>
   <packaging>pom</packaging>
 
   <name>sinicum-server-parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.dievision.sinicum</groupId>
   <artifactId>sinicum-server-parent</artifactId>
-  <version>0.10.4</version>
+  <version>0.10.5</version>
   <packaging>pom</packaging>
 
   <name>sinicum-server-parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.dievision.sinicum</groupId>
   <artifactId>sinicum-server-parent</artifactId>
-  <version>0.10.3</version>
+  <version>0.10.4</version>
   <packaging>pom</packaging>
 
   <name>sinicum-server-parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.dievision.sinicum</groupId>
   <artifactId>sinicum-server-parent</artifactId>
-  <version>0.10.5</version>
+  <version>0.10.6</version>
   <packaging>pom</packaging>
 
   <name>sinicum-server-parent</name>

--- a/sinicum-server-magnolia-5/pom.xml
+++ b/sinicum-server-magnolia-5/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.dievision.sinicum</groupId>
     <artifactId>sinicum-server-parent</artifactId>
-    <version>0.10.3</version>
+    <version>0.10.4</version>
   </parent>
 
   <artifactId>sinicum-server-magnolia-5</artifactId>

--- a/sinicum-server-magnolia-5/pom.xml
+++ b/sinicum-server-magnolia-5/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.dievision.sinicum</groupId>
     <artifactId>sinicum-server-parent</artifactId>
-    <version>0.10.6</version>
+    <version>0.10.7</version>
   </parent>
 
   <artifactId>sinicum-server-magnolia-5</artifactId>

--- a/sinicum-server-magnolia-5/pom.xml
+++ b/sinicum-server-magnolia-5/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.dievision.sinicum</groupId>
     <artifactId>sinicum-server-parent</artifactId>
-    <version>0.10.5</version>
+    <version>0.10.6</version>
   </parent>
 
   <artifactId>sinicum-server-magnolia-5</artifactId>

--- a/sinicum-server-magnolia-5/pom.xml
+++ b/sinicum-server-magnolia-5/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.dievision.sinicum</groupId>
     <artifactId>sinicum-server-parent</artifactId>
-    <version>0.10.4</version>
+    <version>0.10.5</version>
   </parent>
 
   <artifactId>sinicum-server-magnolia-5</artifactId>

--- a/sinicum-server/pom.xml
+++ b/sinicum-server/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.dievision.sinicum</groupId>
     <artifactId>sinicum-server-parent</artifactId>
-    <version>0.10.5</version>
+    <version>0.10.6</version>
   </parent>
 
   <artifactId>sinicum-server</artifactId>

--- a/sinicum-server/pom.xml
+++ b/sinicum-server/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.dievision.sinicum</groupId>
     <artifactId>sinicum-server-parent</artifactId>
-    <version>0.10.3</version>
+    <version>0.10.4</version>
   </parent>
 
   <artifactId>sinicum-server</artifactId>

--- a/sinicum-server/pom.xml
+++ b/sinicum-server/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.dievision.sinicum</groupId>
     <artifactId>sinicum-server-parent</artifactId>
-    <version>0.10.4</version>
+    <version>0.10.5</version>
   </parent>
 
   <artifactId>sinicum-server</artifactId>

--- a/sinicum-server/pom.xml
+++ b/sinicum-server/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.dievision.sinicum</groupId>
     <artifactId>sinicum-server-parent</artifactId>
-    <version>0.10.6</version>
+    <version>0.10.7</version>
   </parent>
 
   <artifactId>sinicum-server</artifactId>

--- a/sinicum-server/src/main/java/com/dievision/sinicum/server/jcr/NavigationProvider.java
+++ b/sinicum-server/src/main/java/com/dievision/sinicum/server/jcr/NavigationProvider.java
@@ -17,6 +17,7 @@ public class NavigationProvider extends NavigationProviderBase {
     private final List<String> properties;
 
     private static final String PAGE_TYPE = "mgnl:page";
+    private static final String HIDDEN_PROPERTY = "nav_hidden";
     private static final Logger logger = LoggerFactory.getLogger(NavigationProvider.class);
 
     public NavigationProvider(String baseNodeUuidOrPath, List<String> properties, int depth)
@@ -31,7 +32,7 @@ public class NavigationProvider extends NavigationProviderBase {
         NodeIterator iterator = node.getNodes();
         while (iterator.hasNext()) {
             Node child = iterator.nextNode();
-            if (PAGE_TYPE.equals(child.getPrimaryNodeType().getName())) {
+            if (PAGE_TYPE.equals(child.getPrimaryNodeType().getName()) && showInNavigation(child)) {
                 NavigationElement element = new NavigationElement(child, properties);
                 if (child.getDepth() <= maximumAllowedDepth()) {
                     element.setChildren(findNavigationElements(child));
@@ -40,6 +41,14 @@ public class NavigationProvider extends NavigationProviderBase {
             }
         }
         return elements;
+    }
+
+    private boolean showInNavigation(Node node) throws RepositoryException {
+        if (node.hasProperty(HIDDEN_PROPERTY)) {
+            return !node.getProperty(HIDDEN_PROPERTY).getBoolean();
+        } else {
+            return true;
+        }
     }
 
     private int maximumAllowedDepth() throws RepositoryException {

--- a/sinicum-server/src/main/java/com/dievision/sinicum/server/jcr/caching/CacheObserverManager.java
+++ b/sinicum-server/src/main/java/com/dievision/sinicum/server/jcr/caching/CacheObserverManager.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
 import com.dievision.sinicum.server.mgnlAdapters.MgnlContextAdapter;
 
 public class CacheObserverManager {
-    private static final String[] OBSERVED_WORKSPACES = {"config", "data", "dms", "website"};
+    private static final String[] OBSERVED_WORKSPACES = {"data", "dms", "website"};
     private static final Logger logger = LoggerFactory.getLogger(CacheObserverManager.class);
 
     public void registerObservers() {

--- a/sinicum-server/src/main/java/com/dievision/sinicum/server/jcr/caching/CachingEventListener.java
+++ b/sinicum-server/src/main/java/com/dievision/sinicum/server/jcr/caching/CachingEventListener.java
@@ -1,5 +1,7 @@
 package com.dievision.sinicum.server.jcr.caching;
 
+import javax.jcr.RepositoryException;
+import javax.jcr.observation.Event;
 import javax.jcr.observation.EventIterator;
 import javax.jcr.observation.EventListener;
 
@@ -9,10 +11,23 @@ import org.slf4j.LoggerFactory;
 public class CachingEventListener implements EventListener {
     private static final Logger logger = LoggerFactory.getLogger(CachingEventListener.class);
 
-    @Override
     public void onEvent(EventIterator events) {
         if (events.hasNext()) {
+            Event event = events.nextEvent();
+            try {
+                if (!event.getPath().startsWith("/jcr:system")) {
+                    String sitePrefix = returnSitePrefix(event.getPath());
+                    GlobalRepositoryState.updateCacheKey(sitePrefix);
+                }
+            } catch (RepositoryException e) {
+                e.printStackTrace();
+            }
             GlobalRepositoryState.updateCacheKey();
         }
+    }
+
+    private String returnSitePrefix(String path) {
+        String[] parts = path.split("/");
+        return parts[1];
     }
 }

--- a/sinicum-server/src/main/java/com/dievision/sinicum/server/jcr/caching/GlobalRepositoryState.java
+++ b/sinicum-server/src/main/java/com/dievision/sinicum/server/jcr/caching/GlobalRepositoryState.java
@@ -4,8 +4,11 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+
 public final class GlobalRepositoryState {
     private static String cacheKey;
+    private static HashMap<String, String> cacheKeys = new HashMap<String, String>();
     private static final Logger logger = LoggerFactory.getLogger(GlobalRepositoryState.class);
 
     private GlobalRepositoryState() {
@@ -14,13 +17,25 @@ public final class GlobalRepositoryState {
 
     public static String getCacheKey() {
         if (cacheKey == null) {
-            updateCacheKey();
+            GlobalRepositoryState.updateCacheKey();
         }
         return cacheKey;
+    }
+
+    public static String getCacheKey(String sitePrefix) {
+        if (!cacheKeys.containsKey(sitePrefix)) {
+            GlobalRepositoryState.updateCacheKey(sitePrefix);
+        }
+        return cacheKeys.get(sitePrefix);
     }
 
     public static void updateCacheKey() {
         String time = Long.toString(System.currentTimeMillis());
         cacheKey = DigestUtils.shaHex(time);
+    }
+
+    public static void updateCacheKey(String sitePrefix) {
+        String time = Long.toString(System.currentTimeMillis());
+        cacheKeys.put(sitePrefix, DigestUtils.shaHex(sitePrefix + time));
     }
 }

--- a/sinicum-server/src/main/java/com/dievision/sinicum/server/jcr/caching/GlobalRepositoryState.java
+++ b/sinicum-server/src/main/java/com/dievision/sinicum/server/jcr/caching/GlobalRepositoryState.java
@@ -17,14 +17,14 @@ public final class GlobalRepositoryState {
 
     public static String getCacheKey() {
         if (cacheKey == null) {
-            GlobalRepositoryState.updateCacheKey();
+            updateCacheKey();
         }
         return cacheKey;
     }
 
     public static String getCacheKey(String sitePrefix) {
         if (!cacheKeys.containsKey(sitePrefix)) {
-            GlobalRepositoryState.updateCacheKey(sitePrefix);
+            updateCacheKey(sitePrefix);
         }
         return cacheKeys.get(sitePrefix);
     }

--- a/sinicum-server/src/main/java/com/dievision/sinicum/server/resources/CacheResource.java
+++ b/sinicum-server/src/main/java/com/dievision/sinicum/server/resources/CacheResource.java
@@ -2,6 +2,7 @@ package com.dievision.sinicum.server.resources;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
@@ -21,9 +22,28 @@ public class CacheResource {
         return new GlobalCacheKeyWrapper();
     }
 
+    @GET
+    @Path("/site/{sitePrefix: .+}")
+    public GlobalCacheKeyWrapper globalKey(@PathParam("sitePrefix") String sitePrefix) {
+        return new GlobalCacheKeyWrapper(sitePrefix);
+    }
+
     private static class GlobalCacheKeyWrapper {
+        private String sitePrefix;
+
+        public GlobalCacheKeyWrapper() {
+        }
+
+        public GlobalCacheKeyWrapper(String sitePrefix) {
+            this.sitePrefix = sitePrefix;
+        }
+
         public String getCacheKey() {
-            return GlobalRepositoryState.getCacheKey();
+            if (sitePrefix == null) {
+                return GlobalRepositoryState.getCacheKey();
+            } else {
+                return GlobalRepositoryState.getCacheKey(sitePrefix);
+            }
         }
     }
 }

--- a/sinicum-server/src/test/java/com/dievision/sinicum/server/jcr/NavigationProviderTest.java
+++ b/sinicum-server/src/test/java/com/dievision/sinicum/server/jcr/NavigationProviderTest.java
@@ -27,6 +27,7 @@ public class NavigationProviderTest extends JackrabbitTest45 {
         Node node00 = node0.addNode("00", "mgnl:page");
         node00.setProperty("title", "Title");
         node00.setProperty("navigation_title", "Navigation Title");
+        node00.setProperty("nav_hidden", false);
         Node node01 = node0.addNode("01", "mgnl:page");
         Node area = node0.addNode("00area", "mgnl:area");
         Node node000 = node00.addNode("000", "mgnl:page");

--- a/sinicum-server/src/test/java/com/dievision/sinicum/server/jcr/caching/GlobalRepositoryStateTest.java
+++ b/sinicum-server/src/test/java/com/dievision/sinicum/server/jcr/caching/GlobalRepositoryStateTest.java
@@ -12,14 +12,21 @@ public class GlobalRepositoryStateTest {
 
     @Test
     public void testReturnCacheKey() {
-        String key = GlobalRepositoryState.getCacheKey();
+        String key = GlobalRepositoryState.getCacheKey("dievision");
         assertTrue(key.matches(".{40}"));
     }
 
     @Test
     public void testUpdateCacheKey() {
-        String key = GlobalRepositoryState.getCacheKey();
-        GlobalRepositoryState.updateCacheKey();
-        assertFalse(key.equals(GlobalRepositoryState.getCacheKey()));
+        String keyDievision = GlobalRepositoryState.getCacheKey("dievision");
+        GlobalRepositoryState.updateCacheKey("dievision");
+        assertFalse(keyDievision.equals(GlobalRepositoryState.getCacheKey("dievision")));
+    }
+
+    @Test
+    public void testDifferentCacheKeys() {
+        String keyDievision = GlobalRepositoryState.getCacheKey("dievision");
+        String keyCody = GlobalRepositoryState.getCacheKey("cody");
+        assertFalse(keyDievision.equals(keyCody));
     }
 }


### PR DESCRIPTION
At the moment, we only have a global cache key. This key gets updated every time a user published a node from the website, data or dms workspace - which is okay in an environment with only one website.
But in a multisite environment, this means, that user A publishes something in his part of the CMS - let's say the node "/test_a/meta/search" - which will update the global cache key. But this would mean that the cache for user B and his part of the CMS ("/test_b") is also updated and needs to be rendered again in the Rails FE.

To get rid of this drawback, I have added a new method, that will save a cache key in the scope of a site prefix. So user A gets his own cache key for his part "/test_a" and user B will get his own cache key for "/test_b".

This change is non-breaking, the old behaviour is still there.