### PR TITLE
Navigation uses the nav_hidden attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ include the following dependency:
 <dependency>
   <groupId>com.dievision.sinicum</groupId>
   <artifactId>sinicum-server-magnolia-5</artifactId>
-  <version>0.10.1</version>
+  <version>0.11.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.dievision.sinicum</groupId>
   <artifactId>sinicum-server-parent</artifactId>
-  <version>0.10.3</version>
+  <version>0.11.0</version>
   <packaging>pom</packaging>
 
   <name>sinicum-server-parent</name>

--- a/sinicum-server-magnolia-5/pom.xml
+++ b/sinicum-server-magnolia-5/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.dievision.sinicum</groupId>
     <artifactId>sinicum-server-parent</artifactId>
-    <version>0.10.3</version>
+    <version>0.11.0</version>
   </parent>
 
   <artifactId>sinicum-server-magnolia-5</artifactId>

--- a/sinicum-server/pom.xml
+++ b/sinicum-server/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.dievision.sinicum</groupId>
     <artifactId>sinicum-server-parent</artifactId>
-    <version>0.10.3</version>
+    <version>0.11.0</version>
   </parent>
 
   <artifactId>sinicum-server</artifactId>

--- a/sinicum-server/src/main/java/com/dievision/sinicum/server/jcr/NavigationProvider.java
+++ b/sinicum-server/src/main/java/com/dievision/sinicum/server/jcr/NavigationProvider.java
@@ -17,6 +17,7 @@ public class NavigationProvider extends NavigationProviderBase {
     private final List<String> properties;
 
     private static final String PAGE_TYPE = "mgnl:page";
+    private static final String HIDDEN_PROPERTY = "nav_hidden";
     private static final Logger logger = LoggerFactory.getLogger(NavigationProvider.class);
 
     public NavigationProvider(String baseNodeUuidOrPath, List<String> properties, int depth)
@@ -31,7 +32,7 @@ public class NavigationProvider extends NavigationProviderBase {
         NodeIterator iterator = node.getNodes();
         while (iterator.hasNext()) {
             Node child = iterator.nextNode();
-            if (PAGE_TYPE.equals(child.getPrimaryNodeType().getName())) {
+            if (PAGE_TYPE.equals(child.getPrimaryNodeType().getName()) && showInNavigation(child)) {
                 NavigationElement element = new NavigationElement(child, properties);
                 if (child.getDepth() <= maximumAllowedDepth()) {
                     element.setChildren(findNavigationElements(child));
@@ -40,6 +41,14 @@ public class NavigationProvider extends NavigationProviderBase {
             }
         }
         return elements;
+    }
+
+    private boolean showInNavigation(Node node) throws RepositoryException {
+        if (node.hasProperty(HIDDEN_PROPERTY)) {
+            return !node.getProperty(HIDDEN_PROPERTY).getBoolean();
+        } else {
+            return true;
+        }
     }
 
     private int maximumAllowedDepth() throws RepositoryException {


### PR DESCRIPTION
The goal is: the navigation should only render the nodes that will be visible.

Currently we collect all child nodes up to a specific depth from a base node and filter on the client side. This produces in some cases huge loading times, since we search for children in nodes, that are hidden anyway.
With this change, the filtering is moved to the server side.